### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0-action-2
+        uses: turion/get-tested@v0.1.5.0-action-4
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0-action-4
+        uses: turion/get-tested@v0.1.5.0-action-5
         with:
           cabal-file: get-tested.cabal
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0
+        uses: turion/get-tested@v0.1.5.0-action
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Generate matrix
         uses: turion/get-tested@v0.1.5.0-action-4
+        with:
+          cabal-file: get-tested.cabal
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0-action-5
+        uses: turion/get-tested@v0.1.5.0
         with:
           cabal-file: get-tested.cabal
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0-action
+        uses: turion/get-tested@v0.1.5.0-action-1
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix
-        uses: turion/get-tested@v0.1.5.0-action-1
+        uses: turion/get-tested@v0.1.5.0-action-2
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,9 @@ jobs:
   generate-matrix:
     name: "Generate matrix from cabal"
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Checkout base repo
-        uses: actions/checkout@v4
-      - name: Extract the tested GHC versions
-        id: set-matrix
-        run: |
-          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
-          chmod +x get-tested
-          ./get-tested --ubuntu --macos get-tested.cabal >> $GITHUB_OUTPUT
+      - name: Generate matrix
+        uses: turion/get-tested@v0.1.5.0
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract the tested GHC versions
-        uses: turion/get-tested@v0.1.5.0-action-5
+        uses: turion/get-tested@v0.1.5.0
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generateMatrix

--- a/README.md
+++ b/README.md
@@ -7,26 +7,18 @@ A CLI tool that retrieves the `tested-with` stanza of a cabal file and formats i
 Put this in your GitHub Action file
 
 ```yaml
-jobs:                                                                                                                   
-  generateMatrix:                                                                                                       
-    name: "Generate matrix from cabal"                                                                                  
-    runs-on: ubuntu-latest                                                                                              
-    outputs:                                                                                                            
-      matrix: ${{ steps.set-matrix.outputs.matrix }}                                                                    
-    steps:                                                                                                              
-      - name: Checkout base repo                                                                                        
-        uses: actions/checkout@v2                                                                                       
-      - name: Extract the tested GHC versions                                                                           
-        id: set-matrix                                                                                                  
-        run: |                                                                                                          
-          wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
-          chmod +x get-tested                                                                                           
-          ./get-tested --ubuntu --macos my-project.cabal >> $GITHUB_OUTPUT                                            
-  tests:                                                                                                                
-    name: ${{ matrix.ghc }} on ${{ matrix.os }}                                                                         
-    needs: generateMatrix                                                                                               
-    runs-on: ${{ matrix.os }}                                                                                           
-    strategy:                                                                                                           
+jobs:
+  generateMatrix:
+    name: "Generate matrix from cabal"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        uses: turion/get-tested@v0.1.5.0-action-5
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generateMatrix
+    runs-on: ${{ matrix.os }}
+    strategy:
       matrix: ${{ fromJSON(needs.generateMatrix.outputs.matrix) }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,9 @@ runs:
     - name: Extract the tested GHC versions
       id: set-matrix
       shell: bash
-      env:
-        ACTION_PATH: ${{ env.GITHUB_ACTION_PATH }}
       run: |
         # Extract e.g. 0.1 from /runner/foo/bar/.../v0.1
-        export version=$(basename $ACTION_PATH | tail -c +1)
+        export version=$(basename $GITHUB_ACTION_PATH | tail -c +1)
         wget https://github.com/Kleidukos/get-tested/releases/download/v${version}/get-tested-${version}-linux-amd64 -O get-tested
         chmod +x get-tested
         ./get-tested --ubuntu --macos ${{ inputs.cabal-file }} >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,12 @@ runs:
     - name: Extract the tested GHC versions
       id: set-matrix
       shell: bash
+      env:
+        ACTION_PATH: ${{ env.GITHUB_ACTION_PATH }}
       run: |
-        wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
+        # Extract e.g. 0.1 from /runner/foo/bar/.../v0.1
+        export version=$(basename $ACTION_PATH | tail -c +1)
+        wget https://github.com/Kleidukos/get-tested/releases/download/v${version}/get-tested-${version}-linux-amd64 -O get-tested
         chmod +x get-tested
         ./get-tested --ubuntu --macos ${{ inputs.cabal-file }} >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: |
         # Extract e.g. 0.1 from /runner/foo/bar/.../v0.1
-        export version=$(basename $GITHUB_ACTION_PATH | tail -c +1)
+        export version=$(basename $GITHUB_ACTION_PATH | tail -c +2)
         wget https://github.com/Kleidukos/get-tested/releases/download/v${version}/get-tested-${version}-linux-amd64 -O get-tested
         chmod +x get-tested
         ./get-tested --ubuntu --macos ${{ inputs.cabal-file }} >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,25 @@
+name: "Generate matrix from cabal"
+
+inputs:
+  cabal-file:
+    description: "The path to your cabal file, e.g. somefolder/myproject.cabal"
+    required: true
+
+outputs:
+  matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout base repo
+      uses: actions/checkout@v2
+    - name: Extract the tested GHC versions
+      id: set-matrix
+      run: |
+        wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
+        chmod +x get-tested
+        ./get-tested --ubuntu --macos ${{ inputs.cabal-file }} >> $GITHUB_OUTPUT
+
+branding:
+  icon: 'list'
+  color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
 
 outputs:
   matrix:
-    description: "The GHC version matrix, to be used as `matrix: ${{ fromJSON(needs.your-get-tested-jobname.outputs.matrix) }}`"
+    description: "The GHC version matrix"
     value: ${{ steps.set-matrix.outputs.matrix }}
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,9 @@ inputs:
     required: true
 
 outputs:
-  matrix: ${{ steps.set-matrix.outputs.matrix }}
+  matrix:
+    description: "The GHC version matrix, to be used as `matrix: ${{ fromJSON(needs.your-get-tested-jobname.outputs.matrix) }}`"
+    value: ${{ steps.set-matrix.outputs.matrix }}
 
 runs:
   using: "composite"
@@ -15,6 +17,7 @@ runs:
       uses: actions/checkout@v2
     - name: Extract the tested GHC versions
       id: set-matrix
+      shell: bash
       run: |
         wget https://github.com/Kleidukos/get-tested/releases/download/v0.1.5.0/get-tested-0.1.5.0-linux-amd64 -O get-tested
         chmod +x get-tested


### PR DESCRIPTION
Adds a github action. 

* [ ] Adapt readme
* [ ] Change CI setup to upstream instead of my own repo
* [ ] Figure out what the right tag name would be. Ideally it would be `v0.1.5.0` because we don't want to make a new cabal release, but that would mean moving tags, which isn't great.