### PR TITLE
Make the `version` input optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ inputs:
     required: true
   version:
     description: "Version of the tool"
-    required: true
+    required: false
+    default: ""
   windows:
     description: "(legacy) Enable Windows runner, latest version"
     required: false
@@ -46,8 +47,18 @@ runs:
     - name: Set up options
       shell: bash
       run: |
-        wget -q https://github.com/Kleidukos/get-tested/releases/download/v${{ inputs.version }}/get-tested-${{ inputs.version}}-Linux-static-x86_64.tar.gz
-        tar -xzvf get-tested-${{ inputs.version}}-Linux-static-x86_64.tar.gz
+        gh_release_flags=(
+          --repo Kleidukos/get-tested
+          --pattern 'get-tested-*-Linux-static-x86_64.tar.gz'
+          --output get-tested.tar.gz
+          )
+        if [[ "${{ inputs.version }}" != "" ]]
+        then
+          gh release download "v${{ inputs.version }}" "${gh_release_flags[@]}"
+        else
+          gh release download "${gh_release_flags[@]}"
+        fi
+        tar -xzvf get-tested.tar.gz
         chmod +x get-tested
 
         echo "::debug:: macOS: ${{ inputs.macos-version }}"


### PR DESCRIPTION
We use the GitHub CLI in order to do that: It is installed on the Ubuntu runner, and if no version is provided to `gh release download`, then it defaults to the 'latest' release.