### PR TITLE
Moved get-tested setup to own workflow

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,57 @@
+name: Test actions pipeline
+
+on:
+  pull_request:
+    branches: ['main']
+
+  push:
+    branches: ['main']
+
+jobs:
+  test-action:
+    name: 'Test get-tested action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: create-matrix
+        uses: ./
+        with:
+          cabal-file: get-tested.cabal
+          ubuntu-version: 'latest'
+          macos-version: 'latest'
+
+      - name: Output matrix
+        run: |
+          jq '.' <<< "${{ steps.create-matrix.matrix }}"
+
+  test-setup-action:
+    name: 'Test setup-get-tested action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up without options
+        id: setup
+        uses: ./setup-get-tested
+
+      - name: Set up with explicit directory
+        id: setup-with-directory
+        uses: ./setup-get-tested
+        with:
+          directory: "my-bin-dir"
+
+      - name: Output results
+        run: |
+          echo "${{ steps.setup.path }}"
+          if [[ -x "${{ steps.setup.path }}" ]]; then
+            echo "Is executable"
+          else
+            echo "Is NOT executable"
+            exit 1
+          fi
+
+          echo "${{ steps.setup-with-directory.path }}"
+          if [[ -x "${{ steps.setup-with-directory.path }}" ]]; then
+            echo "Is executable"
+          else
+            echo "Is NOT executable"
+            exit 1
+          fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -46,16 +46,16 @@ jobs:
 
       - name: Output results
         run: |
-          echo "${{ steps.setup.path }}"
-          if [[ -x "${{ steps.setup.path }}" ]]; then
+          echo "${{ steps.setup.outputs.path }}"
+          if [[ -x "${{ steps.setup.outputs.path }}" ]]; then
             echo "Is executable"
           else
             echo "Is NOT executable"
             exit 1
           fi
 
-          echo "${{ steps.setup-with-directory.path }}"
-          if [[ -x "${{ steps.setup-with-directory.path }}" ]]; then
+          echo "${{ steps.setup-with-directory.outputs.path }}"
+          if [[ -x "${{ steps.setup-with-directory.outputs.path }}" ]]; then
             echo "Is executable"
           else
             echo "Is NOT executable"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,6 +12,9 @@ jobs:
     name: 'Test get-tested action'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
       - name: Extract the tested GHC versions
         id: create-matrix
         uses: ./
@@ -28,6 +31,9 @@ jobs:
     name: 'Test setup-get-tested action'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
       - name: Set up without options
         id: setup
         uses: ./setup-get-tested

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "The path to your cabal file, e.g. somefolder/myproject.cabal"
     required: true
   version:
-    description: "Version of the tool"
+    description: "Version of the get-tested tool"
     required: false
     default: ""
   windows:
@@ -44,23 +44,15 @@ runs:
   steps:
     - name: Checkout base repo
       uses: actions/checkout@v4
+
+    - name: Set up get-tested
+      uses: ./setup-get-tested
+      with:
+        version: ${{ inputs.version }}
+
     - name: Set up options
       shell: bash
       run: |
-        gh_release_flags=(
-          --repo Kleidukos/get-tested
-          --pattern 'get-tested-*-Linux-static-x86_64.tar.gz'
-          --output get-tested.tar.gz
-          )
-        if [[ "${{ inputs.version }}" != "" ]]
-        then
-          gh release download "v${{ inputs.version }}" "${gh_release_flags[@]}"
-        else
-          gh release download "${gh_release_flags[@]}"
-        fi
-        tar -xzvf get-tested.tar.gz
-        chmod +x get-tested
-
         echo "::debug:: macOS: ${{ inputs.macos-version }}"
         echo "::debug:: windows: ${{ inputs.windows-version }}"
         echo "::debug:: ubuntu: ${{ inputs.ubuntu-version }}"

--- a/setup-get-tested/action.yml
+++ b/setup-get-tested/action.yml
@@ -1,0 +1,45 @@
+name: "Set up get-tested"
+description: "Fetches the get-tested tool"
+
+inputs:
+  version:
+    description: "The version of the get-tested tool. Defaults to 'latest' if unspecified."
+    required: false
+    default: ""
+  directory:
+    description: "The directory where the get-tested executable should be placed."
+    required: false
+    default: "."
+
+outputs:
+  path:
+    description: "The path to the get-tested executable."
+    value: ${{ steps.setup.outputs.path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up get-tested
+      id: setup
+      shell: bash
+      run: |
+        gh_release_flags=(
+          --repo Kleidukos/get-tested
+          --pattern 'get-tested-*-Linux-static-x86_64.tar.gz'
+          --output get-tested.tar.gz
+          )
+
+        if [[ "${{ inputs.version }}" != "" ]]; then
+          gh release download "v${{ inputs.version }}" "${gh_release_flags[@]}"
+        else
+          gh release download "${gh_release_flags[@]}"
+        fi
+        tar -x -v -z -f get-tested.tar.gz -C "${{ inputs.directory }}"
+
+        path="${{ inputs.directory }}/get-tested"
+        chmod a+x "${path}"
+        echo "path=${path}" >> "${GITHUB_OUTPUT}"
+
+branding:
+  icon: 'list'
+  color: 'blue'

--- a/setup-get-tested/action.yml
+++ b/setup-get-tested/action.yml
@@ -25,10 +25,13 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        tmpdir="$(mktemp --directory "${RUNNER_TEMP}/setup-get-tested.XXX")"
+        trap "rm -rf ${tmpdir}" EXIT
+
         gh_release_flags=(
           --repo Kleidukos/get-tested
           --pattern 'get-tested-*-Linux-static-x86_64.tar.gz'
-          --output get-tested.tar.gz
+          --output "${tmpdir}/get-tested.tar.gz"
           )
 
         if [[ "${{ inputs.version }}" != "" ]]; then
@@ -37,7 +40,7 @@ runs:
           gh release download "${gh_release_flags[@]}"
         fi
         mkdir -p "${{ inputs.directory }}"
-        tar -x -v -z -f get-tested.tar.gz -C "${{ inputs.directory }}"
+        tar -x -v -z -f "${tmpdir}/get-tested.tar.gz" -C "${{ inputs.directory }}"
 
         path="${{ inputs.directory }}/get-tested"
         chmod a+x "${path}"

--- a/setup-get-tested/action.yml
+++ b/setup-get-tested/action.yml
@@ -22,6 +22,8 @@ runs:
     - name: Set up get-tested
       id: setup
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh_release_flags=(
           --repo Kleidukos/get-tested

--- a/setup-get-tested/action.yml
+++ b/setup-get-tested/action.yml
@@ -34,6 +34,7 @@ runs:
         else
           gh release download "${gh_release_flags[@]}"
         fi
+        mkdir -p "${{ inputs.directory }}"
         tar -x -v -z -f get-tested.tar.gz -C "${{ inputs.directory }}"
 
         path="${{ inputs.directory }}/get-tested"


### PR DESCRIPTION
This way it can be reused if one does need it in other places and not only for build matrix generation.