### PR TITLE
`check` mode

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,23 +2,27 @@ module Main where
 
 import Control.Monad (when)
 import Data.Aeson qualified as Aeson
-import Data.ByteString.Lazy (ByteString)
-import Data.ByteString.Lazy.Char8 qualified as ByteString
 import Data.Function ((&))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Display (display)
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
-import Data.Version (showVersion)
+import Data.Vector.NonEmpty qualified as NEVector
+import Data.Version qualified
+import Distribution.Parsec (parsec, runParsecParser)
+import Distribution.Parsec.FieldLineStream (fieldLineStreamFromString)
+import Distribution.Pretty (prettyShow)
+import Distribution.Types.Version (Version)
 import Effectful
 import Effectful.Console.ByteString (Console)
 import Effectful.Console.ByteString qualified as Console
+import Effectful.Console.ByteString.Lazy qualified as Console.Lazy
 import Effectful.Error.Static
 import Effectful.Error.Static qualified as Error
 import Effectful.FileSystem (FileSystem)
 import Effectful.FileSystem qualified as FileSystem
-import Options.Applicative hiding (action)
+import Options.Applicative
 import System.Exit
 
 import GetTested.CLI.Types
@@ -28,10 +32,12 @@ import Paths_get_tested (version)
 
 main :: IO ()
 main = do
-  result <- execParser (parseOptions `withInfo` "Generate a test matrix from the tested-with stanza of your cabal file")
-  processingResult <- runCLIEff $ runOptions result
+  cmd <- execParser (parser `withInfo` "Generate a test matrix from the tested-with stanza of your cabal file")
+  processingResult <- runCLIEff $ case cmd of
+    CheckCommand options -> check options
+    GenerateCommand options -> generate options
   case processingResult of
-    Right json -> putStrLn $ ByteString.unpack json
+    Right () -> pure ()
     Left (CabalFileNotFound path) -> do
       putStrLn $ "get-tested: Could not find cabal file at path " <> path
       exitFailure
@@ -39,16 +45,51 @@ main = do
       putStrLn $ "get-tested: Could not parse cabal file at path " <> path
       exitFailure
     Left (NoCompilerVersionsFound path) -> do
-      putStrLn $ "get-tested: No compilers found in" <> path
+      putStrLn $ "get-tested: No compilers found in " <> path
       exitFailure
     Left (IncompatibleOptions opt1 opt2) -> do
       putStrLn $ Text.unpack $ "get-tested: Incompatible options: " <> opt1 <> " and " <> opt2 <> " cannot be passed simultaneously."
       exitFailure
+    Left (VersionCheckFailed path failures) -> do
+      putStrLn $
+        "get-tested: Check for "
+          <> path
+          <> " failed:"
+          <> foldMap (\compiler -> "\n  " <> prettyShow compiler) failures
+      exitFailure
 
-parseOptions :: Parser Options
-parseOptions =
-  Options
-    <$> argument str (metavar "FILE")
+parser :: Parser Command
+parser =
+  ( hsubparser (command "check" checkCommandParserInfo)
+      <|> (GenerateCommand <$> generateOptionsParser)
+  )
+    <**> simpleVersioner (Data.Version.showVersion version)
+
+checkCommandParserInfo :: ParserInfo Command
+checkCommandParserInfo =
+  info
+    (CheckCommand <$> checkOptionsParser)
+    (progDesc "Check whether some versions are a subset of the tested versions or not")
+
+checkOptionsParser :: Parser CheckOptions
+checkOptionsParser =
+  CheckOptions
+    <$> (optional . strOption)
+      ( long "from"
+          <> metavar "FILE"
+          <> help "Include the tested versions of this Cabal file"
+          <> action "file"
+      )
+    <*> strArgument (metavar "FILE" <> action "file")
+    <*> (fmap Vector.fromList . many . argument versionReader)
+      ( metavar "VERSION"
+          <> help "Check if this version is one of the tested versions"
+      )
+
+generateOptionsParser :: Parser GenerateOptions
+generateOptionsParser =
+  GenerateOptions
+    <$> strArgument (metavar "FILE" <> action "file")
     <*> switch (long "macos" <> help "(legacy) Enable the macOS runner's latest version")
     <*> optional (strOption (long "macos-version" <> metavar "VERSION" <> help "Enable the macOS runner with the selected version"))
     <*> switch (long "ubuntu" <> help "(legacy) Enable the Ubuntu runner's latest version")
@@ -57,24 +98,50 @@ parseOptions =
     <*> optional (strOption (long "windows-version" <> metavar "VERSION" <> help "Enable the Windows runner with the selected version"))
     <*> switch (long "newest" <> help "Enable only the newest GHC version found in the cabal file")
     <*> switch (long "oldest" <> help "Enable only the oldest GHC version found in the cabal file")
-      <**> simpleVersioner (showVersion version)
 
-runOptions :: Options -> Eff [Console, FileSystem, Error ProcessingError, IOE] ByteString
-runOptions options = do
+check
+  :: (Console :> es, Error ProcessingError :> es, FileSystem :> es)
+  => CheckOptions -> Eff es ()
+check options = do
+  compilers <- extractTestedWith <$> loadFile options.checkOptionsPath
+
+  failures <- case options.checkOptionsFrom of
+    Nothing -> pure $ Vector.filter (`Vector.notElem` compilers) options.checkOptionsVersions
+    Just fp -> do
+      versionsFromFile <- extractTestedWith <$> loadFile fp
+      pure $ Vector.filter (`Vector.notElem` versionsFromFile) compilers
+
+  case NEVector.fromVector failures of
+    Nothing -> pure ()
+    Just failures' ->
+      throwError $ VersionCheckFailed options.checkOptionsPath failures'
+
+generate
+  :: (Console :> es, Error ProcessingError :> es, FileSystem :> es)
+  => GenerateOptions -> Eff es ()
+generate options = do
   checkIncompatibleRelativeOptions options
-  genericPackageDescription <- loadFile options.path
+  genericPackageDescription <- loadFile options.generateOptionsPath
   selectedCompilers <-
     filterCompilers options
-      <$> extractTestedWith options.path genericPackageDescription
+      <$> extractNonEmptyTestedWith options.generateOptionsPath genericPackageDescription
   let filteredList =
-        processOSFlag MacOS options.macosFlag options.macosVersion
-          <> processOSFlag Ubuntu options.ubuntuFlag options.ubuntuVersion
-          <> processOSFlag Windows options.windowsFlag options.windowsVersion
-  if null filteredList
-    then pure $ Aeson.encode selectedCompilers
-    else do
-      let include = PlatformAndVersion <$> filteredList <*> selectedCompilers
-      pure $ "matrix=" <> Aeson.encode (ActionMatrix include)
+        processOSFlag MacOS options.generateOptionsMacosFlag options.generateOptionsMacosVersion
+          <> processOSFlag Ubuntu options.generateOptionsUbuntuFlag options.generateOptionsUbuntuVersion
+          <> processOSFlag Windows options.generateOptionsWindowsFlag options.generateOptionsWindowsVersion
+  Console.Lazy.putStrLn $
+    if null filteredList
+      then Aeson.encode selectedCompilers
+      else
+        let include = PlatformAndVersion <$> filteredList <*> selectedCompilers
+         in "matrix=" <> Aeson.encode (ActionMatrix include)
+
+versionReader :: ReadM Version
+versionReader =
+  eitherReader $
+    either (Left . show) Right
+      . runParsecParser parsec "<versionReader>"
+      . fieldLineStreamFromString
 
 withInfo :: Parser a -> String -> ParserInfo a
 withInfo opts desc = info (helper <*> opts) $ progDesc desc
@@ -97,10 +164,10 @@ processOSFlag runnerOS legacyFallback mExplicitVersion =
 
 checkIncompatibleRelativeOptions
   :: (Error ProcessingError :> es)
-  => Options
+  => GenerateOptions
   -> Eff es ()
 checkIncompatibleRelativeOptions options = do
-  when (options.newest && options.oldest) $
+  when (options.generateOptionsNewest && options.generateOptionsOldest) $
     throwError $
       IncompatibleOptions
         "--newest"
@@ -109,8 +176,8 @@ checkIncompatibleRelativeOptions options = do
 runCLIEff
   :: Eff [Console, FileSystem, Error ProcessingError, IOE] a
   -> IO (Either ProcessingError a)
-runCLIEff action = do
-  action
+runCLIEff run = do
+  run
     & Console.runConsole
     & FileSystem.runFileSystem
     & Error.runErrorNoCallStack

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -80,10 +80,11 @@ executable get-tested
   build-depends:
     , aeson                 ^>=2.2
     , base                  ^>=4.19
-    , bytestring            ^>=0.11
+    , Cabal-syntax          ^>=3.10.3
     , effectful             ^>=2.3
     , effectful-core        ^>=2.3
     , get-tested
+    , nonempty-vector       ^>=0.2.3
     , optparse-applicative  ^>=0.18
     , text                  ^>=2.1
     , text-display          ^>=0.0.1

--- a/src/GetTested/CLI/Types.hs
+++ b/src/GetTested/CLI/Types.hs
@@ -1,16 +1,30 @@
 module GetTested.CLI.Types where
 
 import Data.Text (Text)
+import Data.Vector (Vector)
+import Distribution.Types.Version (Version)
 
-data Options = Options
-  { path :: FilePath
-  , macosFlag :: Bool
-  , macosVersion :: Maybe Text
-  , ubuntuFlag :: Bool
-  , ubuntuVersion :: Maybe Text
-  , windowsFlag :: Bool
-  , windowsVersion :: Maybe Text
-  , newest :: Bool
-  , oldest :: Bool
+data Command
+  = CheckCommand CheckOptions
+  | GenerateCommand GenerateOptions
+  deriving stock (Show, Eq)
+
+data CheckOptions = CheckOptions
+  { checkOptionsFrom :: Maybe FilePath
+  , checkOptionsPath :: FilePath
+  , checkOptionsVersions :: Vector Version
+  }
+  deriving stock (Show, Eq)
+
+data GenerateOptions = GenerateOptions
+  { generateOptionsPath :: FilePath
+  , generateOptionsMacosFlag :: Bool
+  , generateOptionsMacosVersion :: Maybe Text
+  , generateOptionsUbuntuFlag :: Bool
+  , generateOptionsUbuntuVersion :: Maybe Text
+  , generateOptionsWindowsFlag :: Bool
+  , generateOptionsWindowsVersion :: Maybe Text
+  , generateOptionsNewest :: Bool
+  , generateOptionsOldest :: Bool
   }
   deriving stock (Show, Eq)

--- a/src/GetTested/Types.hs
+++ b/src/GetTested/Types.hs
@@ -9,6 +9,7 @@ import Data.Text.Display
 import Data.Text.Lazy.Builder qualified as Builder
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
+import Data.Vector.NonEmpty (NonEmptyVector)
 import Distribution.Compiler
 import Distribution.Parsec (simpleParsec)
 import Distribution.Pretty qualified as Pretty
@@ -21,6 +22,7 @@ data ProcessingError
   | CabalFileCouldNotBeParsed FilePath
   | NoCompilerVersionsFound FilePath
   | IncompatibleOptions Text Text
+  | VersionCheckFailed FilePath (NonEmptyVector Version)
   deriving stock (Eq, Ord, Show)
   deriving
     (Display)

--- a/test/ExtractTest.hs
+++ b/test/ExtractTest.hs
@@ -19,21 +19,21 @@ spec =
 testFilteringNewestCompiler :: TestEff ()
 testFilteringNewestCompiler = do
   let options =
-        Options
-          { path = "./test/fixtures/one.cabal"
-          , macosFlag = False
-          , macosVersion = Nothing
-          , ubuntuFlag = False
-          , ubuntuVersion = Just "latest"
-          , windowsFlag = False
-          , windowsVersion = Nothing
-          , newest = True
-          , oldest = False
+        GenerateOptions
+          { generateOptionsPath = "./test/fixtures/one.cabal"
+          , generateOptionsMacosFlag = False
+          , generateOptionsMacosVersion = Nothing
+          , generateOptionsUbuntuFlag = False
+          , generateOptionsUbuntuVersion = Just "latest"
+          , generateOptionsWindowsFlag = False
+          , generateOptionsWindowsVersion = Nothing
+          , generateOptionsNewest = True
+          , generateOptionsOldest = False
           }
   genericPackageDescription <- Extract.loadFile "./test/fixtures/one.cabal"
   result <-
     Extract.filterCompilers options
-      <$> Extract.extractTestedWith options.path genericPackageDescription
+      <$> Extract.extractNonEmptyTestedWith options.generateOptionsPath genericPackageDescription
   assertEqual
     ""
     (Vector.singleton $ Version.mkVersion [9, 10, 1])
@@ -42,21 +42,21 @@ testFilteringNewestCompiler = do
 testFilteringOldestCompiler :: TestEff ()
 testFilteringOldestCompiler = do
   let options =
-        Options
-          { path = "./test/fixtures/one.cabal"
-          , macosFlag = False
-          , macosVersion = Nothing
-          , ubuntuFlag = False
-          , ubuntuVersion = Just "latest"
-          , windowsFlag = False
-          , windowsVersion = Nothing
-          , newest = False
-          , oldest = True
+        GenerateOptions
+          { generateOptionsPath = "./test/fixtures/one.cabal"
+          , generateOptionsMacosFlag = False
+          , generateOptionsMacosVersion = Nothing
+          , generateOptionsUbuntuFlag = False
+          , generateOptionsUbuntuVersion = Just "latest"
+          , generateOptionsWindowsFlag = False
+          , generateOptionsWindowsVersion = Nothing
+          , generateOptionsNewest = False
+          , generateOptionsOldest = True
           }
   genericPackageDescription <- Extract.loadFile "./test/fixtures/one.cabal"
   result <-
     Extract.filterCompilers options
-      <$> Extract.extractTestedWith options.path genericPackageDescription
+      <$> Extract.extractNonEmptyTestedWith options.generateOptionsPath genericPackageDescription
   assertEqual
     ""
     (Vector.singleton $ Version.mkVersion [8, 10, 7])


### PR DESCRIPTION
This PR adds a `check` command to the get-tested executable:
For instance, `get-tested check package.cabal 9.12.1 9.10.1` will check if the `tested-with` stanza in the `package.cabal` file contains both `GHC ==9.12.1` and `GHC ==9.10.1`.
To make the work with multiple package (e.g. in mono-repos) easier we provide an `--from` option:
`get-tested check --from library.cabal executable.cabal` will check if all compilers listed in the `tested-with` stanza of the `executable.package` appear in the one of the `library.cabal`. The intended use case is a CI pipeline, where the test matrix is generated from the compilers of the `library.cabal`, and we want to check that the `executable.cabal` package living in the same repository does not "lie" about the versions it was actually tested with.

Fixes #49 