### PR TITLE
Add more information to the generated GitHub build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           path: ${{ env.ARTIFACT_NAME }}
 
   build-alpine:
-    name: 9.10.1 on alpine-3.20
+    name: 9.10.2 on alpine-3.20
     runs-on: ubuntu-latest
     container: "alpine:3.20"
     needs: generate-matrix
@@ -118,7 +118,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: "9.10.1"
+          ghc-version: "9.10.2"
           cabal-version: "latest"
 
       - name: Configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
   build-alpine:
     env:
       os: alpine-3.20
-    name: 9.10.1 on alpine-3.20
+    name: 9.10.2 on alpine-3.20
     runs-on: ubuntu-latest
     container: 'alpine:3.20'
     needs: generate-matrix
@@ -127,7 +127,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: '9.10.1'
+          ghc-version: '9.10.2'
           cabal-version: 'latest'
 
       - name: Configure

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: ./
 
-with-compiler: ghc-9.10.1
+with-compiler: ghc-9.10.2
 
 optimization: 2
 

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -9,7 +9,7 @@ license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Hécate Kleidukos
 maintainer:      hecate+github@glitchbra.in
-tested-with:     GHC ==9.10.1
+tested-with:     GHC ==9.10.2
 
 -- copyright:
 category:        Development

--- a/src/GetTested/Types.hs
+++ b/src/GetTested/Types.hs
@@ -66,6 +66,8 @@ data ActionMatrix = ActionMatrix
 data PlatformAndVersion = PlatformAndVersion
   { os :: Text
   , ghc :: Version
+  , oldest :: Bool
+  , newest :: Bool
   }
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (ToJSON)

--- a/src/GetTested/Types.hs
+++ b/src/GetTested/Types.hs
@@ -3,7 +3,6 @@
 module GetTested.Types where
 
 import Data.Aeson
-import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Display


### PR DESCRIPTION
There are now two more fields available in each entry of the build matrix: `oldest` and `newest`. Both fields are boolean values and indicate whether the GHC version of the matrix entry is the newest version or the oldest version respectively that was found in the tested-with stanza of the Cabal file.

Fixes #52 