### PR TITLE
Require `text-display >=1` and updated dependency bounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,23 +1,5 @@
 packages: ./
 
-with-compiler: ghc-9.10
-
-optimization: 2
-
-tests: True
-
-semaphore: True
-
-multi-repl: True
-
-allow-newer: all
-
-test-show-details: direct
-
-package *
-  ghc-options: +RTS -A32m -RTS -j
-  split-sections: True
-
 allow-newer:
     tasty-test-reporter:mtl
   , tasty-test-reporter:ansi-terminal

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,7 @@
 packages: ./
 
+with-compiler: ghc-9.10
+
 allow-newer:
     tasty-test-reporter:mtl
   , tasty-test-reporter:ansi-terminal

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -1,5 +1,7 @@
 import: cabal.project
 
+with-compiler: ghc-9.10
+
 optimization: 2
 
 documentation: False
@@ -7,3 +9,17 @@ documentation: False
 executable-stripping: True
 
 library-stripping: True
+
+tests: True
+
+semaphore: True
+
+multi-repl: True
+
+allow-newer: all
+
+test-show-details: direct
+
+package *
+  ghc-options: +RTS -A32m -RTS -j
+  split-sections: True

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -14,10 +14,6 @@ tests: True
 
 semaphore: True
 
-multi-repl: True
-
-allow-newer: all
-
 test-show-details: direct
 
 package *

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -1,7 +1,5 @@
 import: cabal.project
 
-with-compiler: ghc-9.10
-
 optimization: 2
 
 documentation: False

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -61,7 +61,7 @@ library
 
   build-depends:
     , aeson            ^>=2.2
-    , base             >=4.19 && <4.21
+    , base             >=4.19 && <4.22
     , bytestring       >=0.11 && <0.13
     , Cabal-syntax     >=3.10.3 && <3.15
     , effectful        >=2.3 && <2.6
@@ -78,7 +78,7 @@ executable get-tested
   other-modules:  Paths_get_tested
   build-depends:
     , aeson                 ^>=2.2
-    , base                  >=4.19 && <4.21
+    , base                  >=4.19 && <4.22
     , bytestring            >=0.11 && <0.13
     , effectful             >=2.3 && <2.6
     , get-tested

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -62,7 +62,7 @@ library
   build-depends:
     , aeson            ^>=2.2
     , base             >=4.19 && <4.21
-    , bytestring       ^>=0.11
+    , bytestring       >=0.11 && <0.13
     , Cabal-syntax     ^>=3.10.3
     , effectful        ^>=2.3
     , nonempty-vector  ^>=0.2.3
@@ -79,7 +79,7 @@ executable get-tested
   build-depends:
     , aeson                 ^>=2.2
     , base                  >=4.19 && <4.21
-    , bytestring            ^>=0.11
+    , bytestring            >=0.11 && <0.13
     , effectful             ^>=2.3
     , get-tested
     , optparse-applicative  ^>=0.18

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -68,7 +68,7 @@ library
     , effectful-core   ^>=2.3
     , nonempty-vector  ^>=0.2.3
     , text             ^>=2.1
-    , text-display     ^>=0.0.1
+    , text-display     ^>=1.0
     , vector           ^>=0.13
 
 executable get-tested
@@ -86,7 +86,7 @@ executable get-tested
     , get-tested
     , optparse-applicative  ^>=0.18
     , text                  ^>=2.1
-    , text-display          ^>=0.0.1
+    , text-display          ^>=1.0
     , vector                ^>=0.13
 
   hs-source-dirs: app

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -63,7 +63,7 @@ library
     , aeson            ^>=2.2
     , base             >=4.19 && <4.21
     , bytestring       >=0.11 && <0.13
-    , Cabal-syntax     ^>=3.10.3
+    , Cabal-syntax     >=3.10.3 && <3.15
     , effectful        ^>=2.3
     , nonempty-vector  ^>=0.2.3
     , text             ^>=2.1

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -64,7 +64,7 @@ library
     , base             >=4.19 && <4.21
     , bytestring       >=0.11 && <0.13
     , Cabal-syntax     >=3.10.3 && <3.15
-    , effectful        ^>=2.3
+    , effectful        >=2.3 && <2.6
     , nonempty-vector  ^>=0.2.3
     , text             ^>=2.1
     , text-display     ^>=1.0
@@ -80,7 +80,7 @@ executable get-tested
     , aeson                 ^>=2.2
     , base                  >=4.19 && <4.21
     , bytestring            >=0.11 && <0.13
-    , effectful             ^>=2.3
+    , effectful             >=2.3 && <2.6
     , get-tested
     , optparse-applicative  ^>=0.18
     , text                  ^>=2.1

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -61,7 +61,7 @@ library
 
   build-depends:
     , aeson            ^>=2.2
-    , base             ^>=4.19
+    , base             >=4.19 && <4.21
     , bytestring       ^>=0.11
     , Cabal-syntax     ^>=3.10.3
     , effectful        ^>=2.3
@@ -79,7 +79,7 @@ executable get-tested
   other-modules:  Paths_get_tested
   build-depends:
     , aeson                 ^>=2.2
-    , base                  ^>=4.19
+    , base                  >=4.19 && <4.21
     , bytestring            ^>=0.11
     , effectful             ^>=2.3
     , effectful-core        ^>=2.3

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -65,7 +65,6 @@ library
     , bytestring       ^>=0.11
     , Cabal-syntax     ^>=3.10.3
     , effectful        ^>=2.3
-    , effectful-core   ^>=2.3
     , nonempty-vector  ^>=0.2.3
     , text             ^>=2.1
     , text-display     ^>=1.0
@@ -82,7 +81,6 @@ executable get-tested
     , base                  >=4.19 && <4.21
     , bytestring            ^>=0.11
     , effectful             ^>=2.3
-    , effectful-core        ^>=2.3
     , get-tested
     , optparse-applicative  ^>=0.18
     , text                  ^>=2.1
@@ -106,7 +104,6 @@ test-suite get-tested-test
     , base
     , Cabal-syntax
     , effectful
-    , effectful-core
     , get-tested
     , tasty
     , tasty-hunit

--- a/src/GetTested/Types.hs
+++ b/src/GetTested/Types.hs
@@ -3,10 +3,10 @@
 module GetTested.Types where
 
 import Data.Aeson
+import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Display
-import Data.Text.Lazy.Builder qualified as Builder
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Distribution.Compiler
@@ -45,10 +45,10 @@ instance FromJSON CompilerFlavor where
     maybe (fail "Invalid compiler flavor") pure (simpleParsec $ Text.unpack s)
 
 instance Display CompilerFlavor where
-  displayBuilder = Builder.fromString . Pretty.prettyShow
+  displayBuilder = fromString . Pretty.prettyShow
 
 instance Display VersionRange where
-  displayBuilder = Builder.fromString . Pretty.prettyShow
+  displayBuilder = fromString . Pretty.prettyShow
 
 instance ToJSON Version where
   toJSON = toJSON . Pretty.prettyShow


### PR DESCRIPTION
This PR updates the upper bound of the `text-display` dependency to `>=1` and adjusts the code accordingly.
One problem that lead to the build failure described in #65 was that `allow-newer: all` was set in the `cabal.project` file and all upper version bounds were ignored. I removed that and updated the upper bounds such that each includes the latest version available. I also got the package to build with GHC 9.12.1 (requires `--allow-newer` due to https://github.com/haskell/aeson/issues/1124).

Fixes #65 