### PR TITLE
Prepare for v0.1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.1.9.1 -- 2025-11-10
+
+Move runner validation to GitHub Action https://github.com/Kleidukos/get-tested/pull/85
+Merge pull request #84 from webdevred/more-backwards-compatibility-fixes
+Make setup-get-tested backwards compatible with older naming scheme (#81)
+Merge pull request #80 from webdevred/remove-windows-check
+
 ## 0.1.9.0 -- 2025-10-29
 
 * Require `text-display >=1` and updated dependency bounds by @mmhat in https://github.com/Kleidukos/get-tested/pull/66

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       #
       # See: https://github.com/actions/runner/issues/895
     - name: Set up get-tested
-      uses: Kleidukos/get-tested/setup-get-tested@7c81839e4e72c1124c2de9e1dbf364c513e78afb
+      uses: Kleidukos/get-tested/setup-get-tested@d8562f44cf524ed3f4d17011321e978d0f89d4a3
       with:
         version: ${{ inputs.version }}
 

--- a/get-tested.cabal
+++ b/get-tested.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            get-tested
-version:         0.1.9.0
+version:         0.1.9.1
 synopsis:        Get the tested-with stanza of your Cabal file
 
 -- description:


### PR DESCRIPTION
I updated `action.yml` to use a newer commit hash which does not print some debug log messages, updated the changelog with the backwards compatibility improvements and bump version to v0.1.9.1.

This release will make the action backwards compatible with older `get-tested` executable versions.