### PR TITLE
Enabling multipe runner test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: kleidukos/get-tested@v0.1.10.0-rc1
         with:
           cabal-file: get-tested.cabal
-          ubuntu-version: '24.04, latest'
+          ubuntu-version: 'latest'
           macos-version: 'latest'
           windows-version: 'latest'
           version: 0.1.10.0-rc1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: set-matrix
-        uses: kleidukos/get-tested@v0.1.10.0-rc1
+        uses: kleidukos/get-tested@0.1.10.0-rc1
         with:
           cabal-file: get-tested.cabal
           ubuntu-version: '26.04, latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: kleidukos/get-tested@v0.1.10.0-rc1
         with:
           cabal-file: get-tested.cabal
-          ubuntu-version: '26.04, latest'
+          ubuntu-version: '24.04, latest'
           macos-version: 'latest'
           windows-version: 'latest'
           version: 0.1.10.0-rc1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: set-matrix
-        uses: kleidukos/get-tested@v0.1.9.1
+        uses: kleidukos/get-tested@v0.1.10.0-rc1
         with:
           cabal-file: get-tested.cabal
           ubuntu-version: '26.04, latest'
           macos-version: 'latest'
           windows-version: 'latest'
-          version: 0.1.9.1
+          version: v0.1.10.0-rc1
   build:
     name: "${{ matrix.ghc }} on ${{ matrix.os }}"
     needs: generate-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: kleidukos/get-tested@v0.1.9.1
         with:
           cabal-file: get-tested.cabal
-          ubuntu-version: 'latest'
+          ubuntu-version: '26.04, latest'
           macos-version: 'latest'
           windows-version: 'latest'
           version: 0.1.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: set-matrix
-        uses: kleidukos/get-tested@0.1.10.0-rc1
+        uses: kleidukos/get-tested@v0.1.10.0-rc1
         with:
           cabal-file: get-tested.cabal
           ubuntu-version: '26.04, latest'
           macos-version: 'latest'
           windows-version: 'latest'
-          version: v0.1.10.0-rc1
+          version: 0.1.10.0-rc1
   build:
     name: "${{ matrix.ghc }} on ${{ matrix.os }}"
     needs: generate-matrix

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           cabal-file: get-tested.cabal
           ubuntu-version: '18.04,latest'
+          version: 0.1.10.0-rc1
 
       - name: Output matrix
         shell: bash

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./
         with:
           cabal-file: get-tested.cabal
-          ubuntu-version: '18.04,latest'
+          ubuntu-version: '24.04,latest'
           version: 0.1.10.0-rc1
 
       - name: Output matrix

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -34,13 +34,12 @@ jobs:
           cabal-file: get-tested.cabal
           ubuntu-version: 'latest'
 
-      # TODO: Enable this after releasing a new version of the binary
-      # - name: Extract the tested GHC versions with multiple runner versions
-      #   id: multiple-runner-versions
-      #   uses: ./
-      #   with:
-      #     cabal-file: get-tested.cabal
-      #     ubuntu-version: '18.04,latest'
+      - name: Extract the tested GHC versions with multiple runner versions
+        id: multiple-runner-versions
+        uses: ./
+        with:
+          cabal-file: get-tested.cabal
+          ubuntu-version: '18.04,latest'
 
       - name: Output matrix
         shell: bash
@@ -51,9 +50,9 @@ jobs:
         run:
           jq '.' <<< '${{ steps.old-naming-scheme.outputs.matrix }}'
 
-      # - name: Output matrix for multiple runner versions
-      #   shell: bash
-      #   run: jq '.' <<< '${{ steps.multiple-runner-versions.outputs.matrix }}'
+      - name: Output matrix for multiple runner versions
+        shell: bash
+        run: jq '.' <<< '${{ steps.multiple-runner-versions.outputs.matrix }}'
 
       - name: Set up without options
         id: setup

--- a/action.yml
+++ b/action.yml
@@ -129,9 +129,13 @@ runs:
            exit 1
         fi
         if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$requested_version" ge "$minium_modern_version"; then
+          set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"
+          set +x
         else
+          set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}" >> "$GITHUB_OUTPUT"
+          set +x
         fi
 
 

--- a/action.yml
+++ b/action.yml
@@ -131,11 +131,11 @@ runs:
         if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$requested_version" ge "$minium_modern_version"; then
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"
-          set +x
+          { set +x; } 2>/dev/null
         else
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}" >> "$GITHUB_OUTPUT"
-          set +x
+          { set +x; } 2>/dev/null
         fi
 
 


### PR DESCRIPTION
- **`ci.yml`**: updated action ref and added `26.04` alongside `latest` in the Ubuntu matrix
- **`test-action.yml`**: uncommented the multiple-runner-versions step and its matrix output, which were blocked pending this release
- **`action.yml`**: added `set -x` / `set +x` around the `get-tested` invocations to aid debugging