### PR TITLE
Return simple list when providing `versions-only` parameter

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -42,6 +42,7 @@ jobs:
       #   with:
       #     version: 0.1.7.0
       #     cabal-file: get-tested.cabal
+      #     versions-only: true
 
       - name: Extract the tested GHC versions with multiple runner versions
         id: multiple-runner-versions

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -34,13 +34,14 @@ jobs:
           cabal-file: get-tested.cabal
           ubuntu-version: 'latest'
 
-      - name: Return a simple list of version
-        uses: ./
-        id: simple-list
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        with:
-          version: 0.1.7.0
-          cabal-file: get-tested.cabal
+      # TODO: Uncomment this there is a release with this
+      # - name: Return a simple list of version
+      #   uses: ./
+      #   id: simple-list
+      #   if: ${{ matrix.os == 'ubuntu-latest' }}
+      #   with:
+      #     version: 0.1.7.0
+      #     cabal-file: get-tested.cabal
 
       - name: Extract the tested GHC versions with multiple runner versions
         id: multiple-runner-versions
@@ -59,9 +60,9 @@ jobs:
         run:
           jq '.' <<< '${{ steps.old-naming-scheme.outputs.matrix }}'
 
-      - name: Output matrix for simple list
-        shell: bash
-        run: jq '.' <<< '${{ steps.simple-list.outputs.matrix }}'
+      # - name: Output matrix for simple list
+      #   shell: bash
+      #   run: jq '.' <<< '${{ steps.simple-list.outputs.matrix }}'
 
       - name: Output matrix for multiple runner versions
         shell: bash

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -34,6 +34,14 @@ jobs:
           cabal-file: get-tested.cabal
           ubuntu-version: 'latest'
 
+      - name: Return a simple list of version
+        uses: ./
+        id: simple-list
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          version: 0.1.7.0
+          cabal-file: get-tested.cabal
+
       - name: Extract the tested GHC versions with multiple runner versions
         id: multiple-runner-versions
         uses: ./
@@ -50,6 +58,10 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run:
           jq '.' <<< '${{ steps.old-naming-scheme.outputs.matrix }}'
+
+      - name: Output matrix for simple list
+        shell: bash
+        run: jq '.' <<< '${{ steps.simple-list.outputs.matrix }}'
 
       - name: Output matrix for multiple runner versions
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "Enable only the oldest GHC version found in the cabal file"
     required: false
     default: 'false'
+  ghc-versions-only:
+    description: "Return the list of version only"
+    required: false
+    default: 'false'
 
 outputs:
   matrix:
@@ -124,6 +128,19 @@ runs:
       run: |
         requested_version="${{ inputs.version }}"
         minium_modern_version="0.1.9.0"
+        ghc_versions_only="${{ inputs.ghc-versions-only }}"
+        head-or-default () {
+          [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]]
+        }
+        if head-or-default && [[ "$ghc_versions_only" == "true" ]]; then
+          set -x
+          ./get-tested "${{ inputs.cabal-file }}"
+          { set +x; } 2>/dev/null
+        fi
+        if [[ "$WINDOWS" == "" ]] && [[ "$MACOS" == "" ]] && [[ "$UBUNTU" == "" ]]; then
+           echo "At least one runner needed, please check the README.md in the get-tested repo"
+           exit 1
+        fi
         if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$requested_version" ge "$minium_modern_version"; then
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     description: "Enable only the oldest GHC version found in the cabal file"
     required: false
     default: 'false'
-  ghc-versions-only:
+  versions-only:
     description: "Return the list of version only"
     required: false
     default: 'false'
@@ -128,11 +128,11 @@ runs:
       run: |
         requested_version="${{ inputs.version }}"
         minium_modern_version="0.1.9.0"
-        ghc_versions_only="${{ inputs.ghc-versions-only }}"
+        versions_only="${{ inputs.versions-only }}"
         head-or-default () {
           [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]]
         }
-        if head-or-default && [[ "$ghc_versions_only" == "true" ]]; then
+        if head-or-default && [[ "$versions_only" == "true" ]]; then
           set -x
           ./get-tested "${{ inputs.cabal-file }}"
           { set +x; } 2>/dev/null

--- a/action.yml
+++ b/action.yml
@@ -124,10 +124,6 @@ runs:
       run: |
         requested_version="${{ inputs.version }}"
         minium_modern_version="0.1.9.0"
-        if [[ "$WINDOWS" == "" ]] && [[ "$MACOS" == "" ]] && [[ "$UBUNTU" == "" ]]; then
-           echo "At least one runner needed, please check the README.md in the get-tested repo"
-           exit 1
-        fi
         if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$requested_version" ge "$minium_modern_version"; then
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -50,7 +50,7 @@ saveOutput :: ByteString -> IO ()
 saveOutput json = do
   lookupEnv "CI" >>= maybe printToStdout (const writeToOutput)
   where
-    writeMatrix outputFile = ByteString.writeFile outputFile (json <> "\n")
+    writeMatrix outputFile = ByteString.writeFile outputFile ("matrix=" <> json <> "\n")
     writeToOutput =
       lookupEnv "GITHUB_OUTPUT" >>= maybe printToStdout writeMatrix
     printToStdout = putStrLn $ ByteString.unpack json
@@ -99,7 +99,7 @@ runOptions options = do
     then pure $ Aeson.encode selectedCompilers
     else do
       let include = makePlatformAndVersion <$> filteredList <*> selectedCompilers
-      pure $ "matrix=" <> Aeson.encode (ActionMatrix include)
+      pure $ Aeson.encode (ActionMatrix include)
 
 withInfo :: Parser a -> String -> ParserInfo a
 withInfo opts desc = info (helper <*> opts) $ progDesc desc


### PR DESCRIPTION

Two changes:
1. Move the `matrix=` prefix from the Haskell code into the shell script output handling, so it is always prepended consistently regardless of output type. This is needed so that `versions-only` also gets the `matrix=` prefix in its output.
2. Add a `versions-only` parameter to `action.yml` that skips runner handling and returns just the GHC version list.

```diff
modified   app/Main.hs
@@ -50,7 +50,7 @@ saveOutput :: ByteString -> IO ()
 saveOutput json = do
   lookupEnv "CI" >>= maybe printToStdout (const writeToOutput)
   where
-    writeMatrix outputFile = ByteString.writeFile outputFile (json <> "\n")
+    writeMatrix outputFile = ByteString.writeFile outputFile ("matrix=" <> json <> "\n")
     writeToOutput =
       lookupEnv "GITHUB_OUTPUT" >>= maybe printToStdout writeMatrix
     printToStdout = putStrLn $ ByteString.unpack json
@@ -99,7 +99,7 @@ runOptions options = do
     then pure $ Aeson.encode selectedCompilers
     else do
       let include = makePlatformAndVersion <$> filteredList <*> selectedCompilers
-      pure $ "matrix=" <> Aeson.encode (ActionMatrix include)
+      pure $ Aeson.encode (ActionMatrix include)
```