### PR TITLE
Enable versions-only test

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -30,19 +30,18 @@ jobs:
         id: old-naming-scheme
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          version: 0.1.7.0
+          version: 0.1.10.0-rc2
           cabal-file: get-tested.cabal
           ubuntu-version: 'latest'
 
-      # TODO: Uncomment this there is a release with this
-      # - name: Return a simple list of version
-      #   uses: ./
-      #   id: simple-list
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   with:
-      #     version: 0.1.7.0
-      #     cabal-file: get-tested.cabal
-      #     versions-only: true
+      - name: Return a simple list of version
+        uses: ./
+        id: simple-list
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          version: 0.1.7.0
+          cabal-file: get-tested.cabal
+          versions-only: true
 
       - name: Extract the tested GHC versions with multiple runner versions
         id: multiple-runner-versions
@@ -61,9 +60,9 @@ jobs:
         run:
           jq '.' <<< '${{ steps.old-naming-scheme.outputs.matrix }}'
 
-      # - name: Output matrix for simple list
-      #   shell: bash
-      #   run: jq '.' <<< '${{ steps.simple-list.outputs.matrix }}'
+      - name: Output matrix for simple list
+        shell: bash
+        run: jq '.' <<< '${{ steps.simple-list.outputs.matrix }}'
 
       - name: Output matrix for multiple runner versions
         shell: bash

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -30,7 +30,7 @@ jobs:
         id: old-naming-scheme
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          version: 0.1.10.0-rc2
+          version: 0.1.7.0
           cabal-file: get-tested.cabal
           ubuntu-version: 'latest'
 
@@ -39,7 +39,7 @@ jobs:
         id: simple-list
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          version: 0.1.7.0
+          version: 0.1.10.0-rc2
           cabal-file: get-tested.cabal
           versions-only: true
 

--- a/action.yml
+++ b/action.yml
@@ -127,21 +127,28 @@ runs:
       shell: bash
       run: |
         requested_version="${{ inputs.version }}"
+        clean_requested_version="${requested_version%-rc*}"
         minium_modern_version="0.1.9.0"
+        version_only_min_version="0.1.10.0~rc2"
         versions_only="${{ inputs.versions-only }}"
+        normalized_requested="$(echo "$requested_version" | sed 's/-rc/~rc/')"
+
         head-or-default () {
-          [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]]
+          [[ "$clean_requested_version" == "" ]] || [[ "$clean_requested_version" == "get-tested-head" ]]
         }
-        if head-or-default && [[ "$versions_only" == "true" ]]; then
+
+        if [[ "$versions_only" == "true" ]] && { head-or-default || dpkg --compare-versions "$normalized_requested" ge "$version_only_min_version"; }; then
           set -x
           ./get-tested "${{ inputs.cabal-file }}"
           { set +x; } 2>/dev/null
+          exit 0
         fi
+
         if [[ "$WINDOWS" == "" ]] && [[ "$MACOS" == "" ]] && [[ "$UBUNTU" == "" ]]; then
            echo "At least one runner needed, please check the README.md in the get-tested repo"
            exit 1
         fi
-        if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$requested_version" ge "$minium_modern_version"; then
+        if [[ "$clean_requested_version" == "" ]] || [[ "$clean_requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$clean_requested_version" ge "$minium_modern_version"; then
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"
           { set +x; } 2>/dev/null

--- a/action.yml
+++ b/action.yml
@@ -127,14 +127,13 @@ runs:
       shell: bash
       run: |
         requested_version="${{ inputs.version }}"
-        clean_requested_version="${requested_version%-rc*}"
         minium_modern_version="0.1.9.0"
         version_only_min_version="0.1.10.0~rc2"
         versions_only="${{ inputs.versions-only }}"
         normalized_requested="$(echo "$requested_version" | sed 's/-rc/~rc/')"
 
         head-or-default () {
-          [[ "$clean_requested_version" == "" ]] || [[ "$clean_requested_version" == "get-tested-head" ]]
+          [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]]
         }
 
         if [[ "$versions_only" == "true" ]] && { head-or-default || dpkg --compare-versions "$normalized_requested" ge "$version_only_min_version"; }; then
@@ -148,7 +147,7 @@ runs:
            echo "At least one runner needed, please check the README.md in the get-tested repo"
            exit 1
         fi
-        if [[ "$clean_requested_version" == "" ]] || [[ "$clean_requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$clean_requested_version" ge "$minium_modern_version"; then
+        if [[ "$requested_version" == "" ]] || [[ "$requested_version" == "get-tested-head" ]] || dpkg --compare-versions "$normalized_requested" ge "$minium_modern_version"; then
           set -x
           ./get-tested $WINDOWS $MACOS $UBUNTU $RELATIVE_VERSION "${{ inputs.cabal-file }}"
           { set +x; } 2>/dev/null

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
 
         if [[ "$versions_only" == "true" ]] && { head-or-default || dpkg --compare-versions "$normalized_requested" ge "$version_only_min_version"; }; then
           set -x
-          ./get-tested "${{ inputs.cabal-file }}"
+          ./get-tested $RELATIVE_VERSION "${{ inputs.cabal-file }}"
           { set +x; } 2>/dev/null
           exit 0
         fi


### PR DESCRIPTION
## Enable `versions-only` test and version-gate the feature

### What

Activates the previously commented-out `versions-only` which was introduced in #100 test step and adds a minimum version check so the feature is only reachable from `0.1.10.0-rc2` onwards. Related to #93 

### Why

The test was left commented out pending a release that included the feature. That release is now available, so the test is enabled and a version gate is added to prevent older pinned versions from accidentally hitting the `versions-only` path.

### Changes

**`action.yml`**
- Adds `version_only_min_version="0.1.10.0~rc2"` as the minimum version for the `versions-only` path (normalises `-rc` → `~rc` for correct `dpkg` pre-release ordering)
- Strips `-rc*` suffix before the existing `minium_modern_version` comparison so RC builds don't break that check
- Adds `exit 0` after the `versions-only` branch to avoid falling through to the runner-matrix logic

**`.github/workflows/test-action.yml`**
- Uncomments and activates the `simple-list` test step, pinned to `0.1.10.0-rc2`
- Uncomments the corresponding `jq` output step